### PR TITLE
Fixed twisted decorator names

### DIFF
--- a/test/attestation/identity/test_identity.py
+++ b/test/attestation/identity/test_identity.py
@@ -2,7 +2,7 @@ from ipv8.attestation.identity.community import IdentityCommunity
 from ipv8.peer import Peer
 
 from test.base import MockIPv8, TestBase
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 
 class TestIdentityCommunity(TestBase):
@@ -14,7 +14,7 @@ class TestIdentityCommunity(TestBase):
     def create_node(self):
         return MockIPv8(u"curve25519", IdentityCommunity, working_directory=u":memory:")
 
-    @twisted_test
+    @twisted_wrapper
     def test_advertise(self):
         """
         Check if a node can construct an advertisement for his attestest attribute.
@@ -33,7 +33,7 @@ class TestIdentityCommunity(TestBase):
             self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
             self.assertEqual(self.nodes[node_nr].overlay.persistence.get(pk_1, 1).link_sequence_number, 1)
 
-    @twisted_test
+    @twisted_wrapper
     def test_advertise_reject_hash(self):
         """
         Check if unknown hashes are not signed.
@@ -50,7 +50,7 @@ class TestIdentityCommunity(TestBase):
         for node_nr in [0, 1]:
             self.assertIsNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
 
-    @twisted_test
+    @twisted_wrapper
     def test_advertise_reject_public_key(self):
         """
         Check if we don't sign correct hashes for the wrong peer.
@@ -68,7 +68,7 @@ class TestIdentityCommunity(TestBase):
         for node_nr in [0, 1]:
             self.assertIsNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
 
-    @twisted_test
+    @twisted_wrapper
     def test_advertise_reject_old(self):
         """
         Check if we don't sign old attestations.
@@ -87,7 +87,7 @@ class TestIdentityCommunity(TestBase):
         for node_nr in [0, 1]:
             self.assertIsNone(self.nodes[node_nr].overlay.persistence.get(pk_1, 1))
 
-    @twisted_test
+    @twisted_wrapper
     def test_advertise_reject_wrong_name(self):
         """
         Check if we don't sign attestations with incorrect metadata.

--- a/test/attestation/trustchain/test_community.py
+++ b/test/attestation/trustchain/test_community.py
@@ -1,7 +1,7 @@
 from ipv8.attestation.trustchain.community import TrustChainCommunity, UNKNOWN_SEQ
 from test.base import TestBase
 from test.mocking.ipv8 import MockIPv8
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 
 class TestTrustChainCommunity(TestBase):
@@ -13,7 +13,7 @@ class TestTrustChainCommunity(TestBase):
     def create_node(self):
         return MockIPv8(u"curve25519", TrustChainCommunity, working_directory=u":memory:")
 
-    @twisted_test
+    @twisted_wrapper
     def test_sign_half_block(self):
         """
         Check if a block signed by one party is stored in the databases of both parties.
@@ -33,7 +33,7 @@ class TestTrustChainCommunity(TestBase):
             self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get(my_pubkey, 1))
             self.assertEqual(self.nodes[node_nr].overlay.persistence.get(my_pubkey, 1).link_sequence_number, UNKNOWN_SEQ)
 
-    @twisted_test
+    @twisted_wrapper
     def test_sign_full_block(self):
         """
         Check if a double signed transaction is stored in the databases of both parties.
@@ -50,7 +50,7 @@ class TestTrustChainCommunity(TestBase):
             self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get(his_pubkey, 1))
             self.assertEqual(self.nodes[node_nr].overlay.persistence.get(his_pubkey, 1).link_sequence_number, 1)
 
-    @twisted_test
+    @twisted_wrapper
     def test_get_linked(self):
         """
         Check if a both halves of a fully signed block link to each other.
@@ -70,7 +70,7 @@ class TestTrustChainCommunity(TestBase):
             self.assertEqual(self.nodes[node_nr].overlay.persistence.get_linked(my_block), his_block)
             self.assertEqual(self.nodes[node_nr].overlay.persistence.get_linked(his_block), my_block)
 
-    @twisted_test
+    @twisted_wrapper
     def test_crawl(self):
         """
         Check if a block can be crawled.
@@ -102,7 +102,7 @@ class TestTrustChainCommunity(TestBase):
         self.assertIsNotNone(self.nodes[1].overlay.persistence.get(my_pubkey, 1))
         self.assertEqual(self.nodes[1].overlay.persistence.get(my_pubkey, 1).link_sequence_number, UNKNOWN_SEQ)
 
-    @twisted_test
+    @twisted_wrapper
     def test_crawl_default(self):
         """
         Check if the default crawl strategy produces blocks.
@@ -130,7 +130,7 @@ class TestTrustChainCommunity(TestBase):
         self.assertIsNotNone(self.nodes[1].overlay.persistence.get(my_pubkey, 1))
         self.assertEqual(self.nodes[1].overlay.persistence.get(my_pubkey, 1).link_sequence_number, UNKNOWN_SEQ)
 
-    @twisted_test
+    @twisted_wrapper
     def test_crawl_no_blocks(self):
         """
         Check if blocks don't magically appear.
@@ -144,7 +144,7 @@ class TestTrustChainCommunity(TestBase):
 
         self.assertIsNone(self.nodes[1].overlay.persistence.get(my_pubkey, 0))
 
-    @twisted_test
+    @twisted_wrapper
     def test_crawl_negative_index(self):
         """
         Check if a block can be crawled by negative range.
@@ -169,7 +169,7 @@ class TestTrustChainCommunity(TestBase):
         self.assertIsNotNone(self.nodes[1].overlay.persistence.get(my_pubkey, 1))
         self.assertEqual(self.nodes[1].overlay.persistence.get(my_pubkey, 1).link_sequence_number, UNKNOWN_SEQ)
 
-    @twisted_test
+    @twisted_wrapper
     def test_parallel_blocks(self):
         """
         Check if blocks created in parallel will properly be stored in the database.
@@ -202,7 +202,7 @@ class TestTrustChainCommunity(TestBase):
             self.assertIsNotNone(self.nodes[node_nr].overlay.persistence.get(his_pubkey, 2))
             self.assertEqual(self.nodes[node_nr].overlay.persistence.get(his_pubkey, 2).link_sequence_number, second)
 
-    @twisted_test
+    @twisted_wrapper
     def test_retrieve_missing_block(self):
         """
         Check if missing blocks are retrieved through a crawl request.

--- a/test/attestation/wallet/test_attestation_community.py
+++ b/test/attestation/wallet/test_attestation_community.py
@@ -4,7 +4,7 @@ from ipv8.attestation.wallet.primitives.attestation import binary_relativity_sha
 from ipv8.attestation.wallet.community import Attestation, AttestationCommunity, BonehPrivateKey
 
 from test.base import MockIPv8, TestBase
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 
 class TestCommunity(TestBase):
@@ -19,7 +19,7 @@ class TestCommunity(TestBase):
     def create_node(self):
         return MockIPv8(u"curve25519", AttestationCommunity, working_directory=u":memory:")
 
-    @twisted_test
+    @twisted_wrapper
     def test_request_attestation_callback(self):
         """
         Check if the request_attestation callback is correctly called.
@@ -45,7 +45,7 @@ class TestCommunity(TestBase):
         # Request for attribute attestation goes unanswered
         self.nodes[1].overlay.request_cache.clear()
 
-    @twisted_test(4)
+    @twisted_wrapper(4)
     def test_request_attestation(self):
         """
         Check if the request_attestation callback is correctly called.
@@ -72,7 +72,7 @@ class TestCommunity(TestBase):
         self.assertEqual(1, len(db_entries))
         self.assertTrue(f.called)
 
-    @twisted_test(4)
+    @twisted_wrapper(4)
     def test_verify_attestation(self):
         """
         Check if an attestation can be verified.

--- a/test/messaging/anonymization/test_community.py
+++ b/test/messaging/anonymization/test_community.py
@@ -3,7 +3,7 @@ from ipv8.messaging.interfaces.udp.endpoint import UDPEndpoint
 from test.base import TestBase
 from test.mocking.endpoint import MockEndpointListener
 from test.mocking.ipv8 import MockIPv8
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 
 class TestTunnelCommunity(TestBase):
@@ -36,7 +36,7 @@ class TestTunnelCommunity(TestBase):
         ipv8.overlay.settings.max_circuits = 1
         return ipv8
 
-    @twisted_test
+    @twisted_wrapper
     def test_introduction_as_exit(self):
         """
         Check if introduction requests share the fact that nodes are exit nodes.
@@ -49,7 +49,7 @@ class TestTunnelCommunity(TestBase):
         self.assertIn(self.nodes[0].my_peer.public_key.key_to_bin(), self.nodes[1].overlay.exit_candidates)
         self.assertNotIn(self.nodes[1].my_peer.public_key.key_to_bin(), self.nodes[0].overlay.exit_candidates)
 
-    @twisted_test
+    @twisted_wrapper
     def test_introduction_as_exit_twoway(self):
         """
         Check if two nodes can have each other as exit nodes.
@@ -62,7 +62,7 @@ class TestTunnelCommunity(TestBase):
         self.assertIn(self.nodes[0].my_peer.public_key.key_to_bin(), self.nodes[1].overlay.exit_candidates)
         self.assertIn(self.nodes[1].my_peer.public_key.key_to_bin(), self.nodes[0].overlay.exit_candidates)
 
-    @twisted_test
+    @twisted_wrapper
     def test_introduction_as_exit_noway(self):
         """
         Check if two nodes don't advertise themselves as exit node incorrectly.
@@ -75,7 +75,7 @@ class TestTunnelCommunity(TestBase):
         self.assertEqual(len(self.nodes[0].overlay.exit_candidates), 0)
         self.assertEqual(len(self.nodes[1].overlay.exit_candidates), 0)
 
-    @twisted_test
+    @twisted_wrapper
     def test_create_circuit(self):
         """
         Check if 1 hop circuit creation works.
@@ -95,7 +95,7 @@ class TestTunnelCommunity(TestBase):
         # Node 1 has an exit socket open
         self.assertEqual(len(self.nodes[1].overlay.exit_sockets), 1)
 
-    @twisted_test
+    @twisted_wrapper
     def test_create_circuit_no_exit(self):
         """
         Check if 1 hop circuit creation fails without exit nodes.
@@ -112,7 +112,7 @@ class TestTunnelCommunity(TestBase):
         # Node 1 should not have an exit socket open
         self.assertEqual(len(self.nodes[1].overlay.exit_sockets), 0)
 
-    @twisted_test
+    @twisted_wrapper
     def test_destroy_circuit(self):
         """
         Check if a 1 hop circuit can be destroyed.
@@ -131,7 +131,7 @@ class TestTunnelCommunity(TestBase):
         # Node 1 should not have an exit socket open
         self.assertEqual(len(self.nodes[1].overlay.exit_sockets), 0)
 
-    @twisted_test
+    @twisted_wrapper
     def test_destroy_circuit_bad_id(self):
         """
         Check if the correct circuit gets destroyed.
@@ -151,7 +151,7 @@ class TestTunnelCommunity(TestBase):
         # Node 1 still has an exit socket open
         self.assertEqual(len(self.nodes[1].overlay.exit_sockets), 1)
 
-    @twisted_test
+    @twisted_wrapper
     def test_tunnel_data(self):
         """
         Check if data is correctly exited.
@@ -183,7 +183,7 @@ class TestTunnelCommunity(TestBase):
         self.assertEqual(len(ep_listener.received_packets), 1)
         self.assertEqual(ep_listener.received_packets[0][1], data)
 
-    @twisted_test
+    @twisted_wrapper
     def test_two_hop_circuit(self):
         """
         Check if a two hop circuit is correctly created.
@@ -200,7 +200,7 @@ class TestTunnelCommunity(TestBase):
 
         self.assertEqual(self.nodes[0].overlay.tunnels_ready(2), 1.0)
 
-    @twisted_test
+    @twisted_wrapper
     def test_three_hop_circuit(self):
         """
         Check if a three hop circuit is correctly created.
@@ -218,7 +218,7 @@ class TestTunnelCommunity(TestBase):
 
         self.assertEqual(self.nodes[0].overlay.tunnels_ready(3), 1.0)
 
-    @twisted_test
+    @twisted_wrapper
     def test_create_two_circuit(self):
         """
         Check if multiple 1 hop circuit creation works.

--- a/test/messaging/anonymization/test_hiddenservices.py
+++ b/test/messaging/anonymization/test_hiddenservices.py
@@ -6,7 +6,7 @@ from ipv8.peer import Peer
 from test.base import TestBase
 from test.mocking.exit_socket import MockTunnelExitSocket
 from test.mocking.ipv8 import MockIPv8
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 # Map of info_hash -> peer list
 global_dht_services = {}
@@ -93,7 +93,7 @@ class TestHiddenServices(TestBase):
         for exit_socket in exit_sockets:
             exit_sockets[exit_socket] = MockTunnelExitSocket(exit_sockets[exit_socket])
 
-    @twisted_test
+    @twisted_wrapper
     def test_create_introduction_point(self):
         """
         Check if setting up an introduction point works.
@@ -110,7 +110,7 @@ class TestHiddenServices(TestBase):
 
         self.assertTrue(intro_made)
 
-    @twisted_test
+    @twisted_wrapper
     def test_dht_lookup_with_counterparty(self):
         """
         Check if a DHT lookup works.
@@ -139,7 +139,7 @@ class TestHiddenServices(TestBase):
 
         self.assertTrue(callback.called)
 
-    @twisted_test
+    @twisted_wrapper
     def test_dht_lookup_no_counterparty(self):
         """
         Check if a DHT lookup doesn't return on its own required service.

--- a/test/peerdiscovery/deprecated/test_discovery.py
+++ b/test/peerdiscovery/deprecated/test_discovery.py
@@ -1,7 +1,7 @@
 from ipv8.peerdiscovery.deprecated.discovery import _DEFAULT_ADDRESSES
 from test.base import TestBase
 from test.mocking.community import MockCommunity
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 
 class TestDiscoveryCommunity(TestBase):
@@ -20,7 +20,7 @@ class TestDiscoveryCommunity(TestBase):
         for overlay in self.overlays:
             overlay.unload()
 
-    @twisted_test
+    @twisted_wrapper
     def test_bootstrap(self):
         """
         Check if we can bootstrap our peerdiscovery.

--- a/test/peerdiscovery/test_churn.py
+++ b/test/peerdiscovery/test_churn.py
@@ -5,7 +5,7 @@ from ipv8.peerdiscovery.deprecated.discovery import _DEFAULT_ADDRESSES
 from test.base import TestBase
 from test.mocking.community import MockCommunity
 from test.mocking.endpoint import MockEndpointListener
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 
 class TestChurn(TestBase):
@@ -22,7 +22,7 @@ class TestChurn(TestBase):
         for overlay in self.overlays:
             overlay.unload()
 
-    @twisted_test
+    @twisted_wrapper
     def test_keep_reachable(self):
         """
         Check if we don't remove reachable nodes.
@@ -43,7 +43,7 @@ class TestChurn(TestBase):
 
         self.assertEqual(len(self.overlays[0].network.verified_peers), 1)
 
-    @twisted_test
+    @twisted_wrapper
     def test_remove_unreachable(self):
         """
         Check if we remove unreachable nodes.
@@ -68,7 +68,7 @@ class TestChurn(TestBase):
 
         self.assertEqual(len(self.overlays[0].network.verified_peers), 0)
 
-    @twisted_test
+    @twisted_wrapper
     def test_no_nodes(self):
         """
         Nothing should happen if we have no nodes to check.
@@ -84,7 +84,7 @@ class TestChurn(TestBase):
 
         self.assertEqual(len(self.overlays[0].network.verified_peers), 1)
 
-    @twisted_test
+    @twisted_wrapper
     def test_ping_timeout(self):
         """
         Don't overload inactive nodes with pings, send it once within some timeout.
@@ -105,7 +105,7 @@ class TestChurn(TestBase):
 
         self.assertEqual(len(sniffer.received_packets), 1)
 
-    @twisted_test
+    @twisted_wrapper
     def test_ping_timeout_resend(self):
         """
         Don't overload inactive nodes with pings, send it again after some timeout.

--- a/test/peerdiscovery/test_edge_discovery.py
+++ b/test/peerdiscovery/test_edge_discovery.py
@@ -2,7 +2,7 @@ from ipv8.peerdiscovery.discovery import EdgeWalk
 from ipv8.peerdiscovery.deprecated.discovery import _DEFAULT_ADDRESSES
 from test.base import TestBase
 from test.mocking.community import MockCommunity
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 
 class TestEdgeWalk(TestBase):
@@ -19,7 +19,7 @@ class TestEdgeWalk(TestBase):
         for overlay in self.overlays:
             overlay.unload()
 
-    @twisted_test
+    @twisted_wrapper
     def test_take_step(self):
         """
         Check if we will walk to a random other node.
@@ -36,7 +36,7 @@ class TestEdgeWalk(TestBase):
 
         self.assertEqual(len(self.overlays[0].network.verified_peers), 2)
 
-    @twisted_test
+    @twisted_wrapper
     def test_take_step_into(self):
         """
         Check if we will walk to an introduced node.
@@ -64,7 +64,7 @@ class TestEdgeWalk(TestBase):
         self.assertEqual(len(self.overlays[0].network.verified_peers), 2)
         self.assertEqual(len(self.strategies[0].complete_edges), 1)
 
-    @twisted_test
+    @twisted_wrapper
     def test_fail_step_into(self):
         """
         Check if we drop an unreachable introduced node.
@@ -93,7 +93,7 @@ class TestEdgeWalk(TestBase):
         self.assertEqual(len(self.overlays[0].network.verified_peers), 1)
         self.assertEqual(len(self.strategies[0].complete_edges), 0)
 
-    @twisted_test
+    @twisted_wrapper
     def test_complete_edge(self):
         """
         Check if we can complete an edge.

--- a/test/peerdiscovery/test_random_discovery.py
+++ b/test/peerdiscovery/test_random_discovery.py
@@ -2,7 +2,7 @@ from ipv8.peerdiscovery.discovery import RandomWalk
 from ipv8.peerdiscovery.deprecated.discovery import _DEFAULT_ADDRESSES
 from test.base import TestBase
 from test.mocking.community import MockCommunity
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 
 class TestRandomWalk(TestBase):
@@ -19,7 +19,7 @@ class TestRandomWalk(TestBase):
         for overlay in self.overlays:
             overlay.unload()
 
-    @twisted_test
+    @twisted_wrapper
     def test_take_step(self):
         """
         Check if we will walk to a random other node.
@@ -36,7 +36,7 @@ class TestRandomWalk(TestBase):
 
         self.assertEqual(len(self.overlays[0].network.verified_peers), 2)
 
-    @twisted_test
+    @twisted_wrapper
     def test_take_step_into(self):
         """
         Check if we will walk to an introduced node.
@@ -54,7 +54,7 @@ class TestRandomWalk(TestBase):
 
         self.assertEqual(len(self.overlays[0].network.verified_peers), 2)
 
-    @twisted_test
+    @twisted_wrapper
     def test_fail_step_into(self):
         """
         Check if we drop an unreachable introduced node.
@@ -82,7 +82,7 @@ class TestRandomWalk(TestBase):
         self.assertEqual(len(self.overlays[0].network.get_walkable_addresses()), 0)
         self.assertEqual(len(self.overlays[0].network.verified_peers), 1)
 
-    @twisted_test
+    @twisted_wrapper
     def test_retry_step_into(self):
         """
         Check if we don't drop an introduced node immediately.

--- a/test/test_taskmanager.py
+++ b/test/test_taskmanager.py
@@ -4,10 +4,10 @@ from twisted.internet.task import Clock, deferLater, LoopingCall
 
 from ipv8.taskmanager import TaskManager
 from test.base import TestBase
-from test.util import twisted_test
+from test.util import twisted_wrapper
 
 
-def untwisted_test(f):
+def untwisted_wrapper(f):
     """
     We need the reactor for this test.
     But, we don't use it ourselves.
@@ -33,23 +33,23 @@ class TestTaskManager(TestBase):
     def tearDown(self):
         self.tm.cancel_all_pending_tasks()
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_call_later(self):
         self.tm.register_task("test", reactor.callLater(10, lambda: None))
 
         self.assertTrue(self.tm.is_pending_task_active("test"))
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_call_later_and_cancel(self):
         self.tm.register_task("test", reactor.callLater(10, lambda: None))
         self.tm.cancel_pending_task("test")
 
         self.assertFalse(self.tm.is_pending_task_active("test"))
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_call_later_and_replace(self):
         task1 = self.tm.register_task("test", reactor.callLater(10, lambda: None))
         self.tm.replace_task("test", reactor.callLater(10, lambda: None))
@@ -57,39 +57,39 @@ class TestTaskManager(TestBase):
         self.assertTrue(self.tm.is_pending_task_active("test"))
         self.assertFalse(task1.active())
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_looping_call(self):
         self.tm.register_task("test", LoopingCall(lambda: None)).start(10, now=True)
 
         self.assertTrue(self.tm.is_pending_task_active("test"))
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_looping_call_and_cancel(self):
         self.tm.register_task("test", LoopingCall(lambda: None)).start(10, now=True)
         self.tm.cancel_pending_task("test")
 
         self.assertFalse(self.tm.is_pending_task_active("test"))
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_delayed_looping_call_requires_interval(self):
         self.assertRaises(ValueError, self.tm.register_task, "test", LoopingCall(lambda: None), delay=1)
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_delayed_deferred_requires_value(self):
         self.assertRaises(ValueError, self.tm.register_task, "test", deferLater(reactor, 0.0, lambda: None), delay=1)
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_delayed_looping_call_requires_LoopingCall_or_Deferred(self):
         self.assertRaises(ValueError, self.tm.register_task, "test not Deferred nor LoopingCall",
                           self.tm._reactor.callLater(0, lambda: None), delay=1)
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_delayed_looping_call_register_and_cancel_pre_delay(self):
         self.assertFalse(self.tm.is_pending_task_active("test"))
         self.tm.register_task("test", LoopingCall(lambda: None), delay=1, interval=1)
@@ -97,8 +97,8 @@ class TestTaskManager(TestBase):
         self.tm.cancel_pending_task("test")
         self.assertFalse(self.tm.is_pending_task_active("test"))
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_delayed_looping_call_register_wait_and_cancel(self):
         self.assertFalse(self.tm.is_pending_task_active("test"))
         lc = LoopingCall(self.count)
@@ -118,8 +118,8 @@ class TestTaskManager(TestBase):
         self.tm._reactor.advance(10)
         self.assertEquals(2, self.counter)
 
-    @twisted_test
-    @untwisted_test
+    @twisted_wrapper
+    @untwisted_wrapper
     def test_delayed_deferred(self):
         self.assertFalse(self.tm.is_pending_task_active("test"))
         d = Deferred()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,12 +4,12 @@ from twisted.internet.threads import deferToThread
 
 from base import TestBase
 from ipv8.util import blocking_call_on_reactor_thread
-from util import reactor, twisted_test
+from util import reactor, twisted_wrapper
 
 
 class TestUtil(TestBase):
 
-    @twisted_test
+    @twisted_wrapper
     def test_blocking_call(self):
         """
         Check if the reactor thread is properly blocked by a function marked as such.
@@ -43,7 +43,7 @@ class TestUtil(TestBase):
         self.assertEqual(value, 2)
         self.assertEqual(value2, 3)
 
-    @twisted_test
+    @twisted_wrapper
     def test_blocking_call_in_thread(self):
         """
         Check if the reactor thread is properly blocked by a threaded function.
@@ -77,7 +77,7 @@ class TestUtil(TestBase):
         self.assertEqual(value, 2)
         self.assertEqual(value2, 3)
 
-    @twisted_test
+    @twisted_wrapper
     def test_blocking_call_in_thread_with_error(self):
         """
         Check if a blocking call propagates its errors from a thread.

--- a/test/util.py
+++ b/test/util.py
@@ -158,7 +158,7 @@ def deferred(timeout=None):
     return decorate
 
 
-def twisted_test(arg):
+def twisted_wrapper(arg):
     """
     Wrap a twisted test. Optionally supply a test timeout.
 
@@ -166,4 +166,4 @@ def twisted_test(arg):
     """
     if isinstance(arg, (int, long)):
         return lambda x: deferred(arg)(inlineCallbacks(x))
-    return deferred(1)(inlineCallbacks(arg))
+    return deferred(timeout=1)(inlineCallbacks(arg))


### PR DESCRIPTION
Nosetests on MacOS thinks it is a test when it's in the method name and then it fails.